### PR TITLE
Replace break-then-make with double-resize; Add logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,14 +21,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "autorandr-rs"
 version = "0.2.0"
 dependencies = [
  "ansi_term",
  "clap",
  "edid",
+ "log",
  "nom",
  "serde",
+ "stderrlog",
  "toml",
  "x11rb",
 ]
@@ -50,6 +58,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -95,10 +116,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "memchr"
@@ -128,6 +164,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -169,6 +224,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "stderrlog"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a53e2eff3e94a019afa6265e8ee04cb05b9d33fe9f5078b14e4e391d155a38"
+dependencies = [
+ "atty",
+ "chrono",
+ "log",
+ "termcolor",
+ "thread_local",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,12 +254,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
 ]
 
 [[package]]
@@ -222,6 +319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +339,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-wsapoll"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ nom = "3.2"
 toml = "0.5"
 clap = "2.33"
 ansi_term = "0.11"
+log = "0.4"
+stderrlog = "0.5"
 
 [dependencies.serde]
 version = "1.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,7 +27,7 @@ pub mod autorandrd {
                 Arg::with_name("verbosity")
                     .short("v")
                     .multiple(true)
-                    .help("Increase message verbosity")
+                    .help("Increase message verbosity"),
             )
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,12 @@ pub mod autorandrd {
                     .long("check")
                     .help("The configuration file in TOML"),
             )
+            .arg(
+                Arg::with_name("verbosity")
+                    .short("v")
+                    .multiple(true)
+                    .help("Increase message verbosity")
+            )
     }
 }
 

--- a/src/bin/autorandrd.rs
+++ b/src/bin/autorandrd.rs
@@ -163,15 +163,10 @@ fn apply_config<C: Connection>(
         current.w = std::cmp::max(current.w, crtc_info.x as u16 + crtc_info.width);
         current.h = std::cmp::max(current.h, crtc_info.y as u16 + crtc_info.height);
         if x != crtc_info.x || y != crtc_info.y || mode != crtc_info.mode {
-            let rotation = if crtc_info.rotation != 0 {
-                crtc_info.rotation
-            } else {
-                1
-            };
             enables.push(SetCrtcConfigRequest {
                 x,
                 y,
-                rotation,
+                rotation: 1,
                 mode,
                 outputs: vec![out].into(),
                 ..disable_crtc(dest_crtc, &crtc_info)

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,16 @@ pub struct Mode {
     pub h: u16,
 }
 
+impl Mode {
+    /// Create a mode that may contain both modes self and other
+    pub fn union(&self, other: &Self) -> Self {
+        Self {
+            w: std::cmp::max(self.w, other.w),
+            h: std::cmp::max(self.h, other.h),
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for Mode {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = <&str>::deserialize(deserializer)?;


### PR DESCRIPTION
# Summary

Naively reconfiguring monitors can lead to erros, as documented by the
RandR extension:

    'x' and 'y' contain the desired location within the screen for this
    monitor's content. 'x' and 'y' must be within the screen size, else
    a Value error results.

Note that I have found that you can also get a Value erro when the edge
of a configured monitor (well a crtc) would fall outside of the
configured screen size (which is the size of a virtual surface that all
connected monitors display a part of).

In short, reconfiguring a monitor will fail if the monitor contains
pixels outside the screen.

Previously, autorandrd(1) avoided this issue by disabling a monitor
(which I called "break") before re-enabling a monitor (which I called
"make"). This would result in both a screen flicker and a problem for
some hardware that can't easily keep up with these fast screen changes.

Instead, this commit re-configures the screen to allow for space for
both the current monitor config and the final monitor config first,
avoiding the need for a break, as the reconfigure will not error. This
may result in less flickering and may result in fewer calls to the X
server in some situations.

# Example log

```
INFO - Setting Screen Size 5120x2880
INFO - Configuring CRTC 729 to mode 733 at 0,1440
INFO - Configuring CRTC 730 to mode 752 at 0,0
INFO - Setting Screen Size 2560x2880
Monitor configuration: Work-Desktop
```